### PR TITLE
go back to master

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # git+https://github.com/numpy/numpy#egg=numpy
-git+https://github.com/astropy/astropy#a8f496b2#egg=astropy
-git+https://github.com/spacetelescope/asdf#egg=asdf
-git+https://github.com/spacetelescope/gwcs#3e2bc108e#egg=gwcs
-git+https://github.com/astropy/photutils#99f101be#egg=photutils
+git+https://github.com/astropy/astropy#egg=astropy
+git+https://github.com/spacetelescope#egg=asdf
+git+https://github.com/spacetelescope/gwcs#egg=gwcs
+git+https://github.com/astropy/photutils#egg=photutils


### PR DESCRIPTION
Now that jwst/master uses hashes for dependencies we can switch back to using master branches of dependencies in the -dev build.